### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are two ways to run a typical pyATS script:
 ```bash
 $ cd pyats-sample-scripts/basic
 
-$ pyats run job job/basic_example_job.py
+$ pyats run job basic_example_job.py
 
 $ python basic_example_script.py
 ```


### PR DESCRIPTION
corrected command-line example removing second instance of "job" after receiving the following error:

> %CLI-ERROR: The provided jobfile 'job/basic_example_job.py' does not exist.